### PR TITLE
various hot fix

### DIFF
--- a/actions.sh
+++ b/actions.sh
@@ -23,6 +23,10 @@ function run_main() {
     $ENV/bin/python3 -m lib
 }
 
+function run_build() {
+    $ENV/bin/python3 -m build
+}
+
 function run_sonarqube() {
     sonar-scanner
 }
@@ -30,6 +34,11 @@ function run_sonarqube() {
 function run_tests() {
     $ENV/bin/coverage run -m pytest
     $ENV/bin/coverage xml
+}
+
+function run_coverage() {
+    $ENV/bin/coverage run -m pytest
+    $ENV/bin/coverage report
 }
 
 function run_lints() {
@@ -45,6 +54,12 @@ case "$1" in
     'verify')
         verify_python_env
         ;;
+    'build')
+        run_build
+        ;;
+    'coverage')
+        run_coverage
+        ;;
     'CI')
         run_tests
         run_sonarqube
@@ -59,7 +74,7 @@ case "$1" in
         run_lints
         ;;
     *)
-        echo "Usage: $0 { run | verify | test | sonarqube | CI | lint }"
+        echo "Usage: $0 { run | verify | build | coverage | test | sonarqube | CI | lint }"
         exit 1
         ;;
 esac

--- a/docs/guides/en/glossary.md
+++ b/docs/guides/en/glossary.md
@@ -69,7 +69,7 @@ Use `genomic -h`, you will see help screen:
 
 In order to run only tests, use `pytest`.
 
-If you wish to see coverage, `./actions.sh CI` gets the job done.
+If you wish to see coverage, `./actions.sh coverage` gets the job done.
 
 ### Running Lints
 
@@ -82,9 +82,11 @@ With pylint:
 
   - `pylint ./lib/*.py ./tests/*.py --exit-zero`
 
+Or directly with `./actions.sh lint`
+
 ### Running Sonarqube
 
-Use `./actions.sh CI` then `./actions.sh sonarqube`.
+Use `./actions.sh CI`.
 
 ### Creating New Branch
 

--- a/docs/guides/it/glossary.md
+++ b/docs/guides/it/glossary.md
@@ -69,7 +69,7 @@ Usa `genomic -h`, apparira' la schermata di help:
 
 Per far partire i test, usa `pytest`.
 
-Se ti interessa anche visionare la coverage, usa invece `./actions.sh CI`.
+Se ti interessa anche visionare la coverage, usa invece `./actions.sh coverage`.
 
 ### Running Lints
 
@@ -82,9 +82,11 @@ Con pylint:
 
   - `pylint ./lib/*.py ./tests/*.py --exit-zero`
 
+O direttamente con `./actions.sh lint`
+
 ### Running Sonarqube
 
-Usa `./actions.sh CI`, quindi `./actions.sh sonarqube`.
+Usa `./actions.sh CI`.
 
 ### Creating New Branch
 

--- a/lib/__main__.py
+++ b/lib/__main__.py
@@ -51,7 +51,7 @@ CIGAR_STRING_REGEX = "^([0-9]+[MIDSHP=X])*[0-9]+N([0-9]+[MIDSHP=X])*$"
 def workflow(
         bamfile_path: str, fastafile_path: str,
         reference_name: str, csvfile_path: str,
-        jobs: int):
+        intermediate_path: str, jobs: int):
     """
         @does default workflow
     """
@@ -64,7 +64,7 @@ def workflow(
             reference = fastafile.get_reference(reference_name)
 
             csvfile: CsvFile
-            with CsvFile(csvfile_path) as csvfile:
+            with CsvFile(intermediate_path) as csvfile:
                 csvfile.rebase([
                     "id",
                     "cigar_string",
@@ -93,11 +93,11 @@ def workflow(
                             csvfile.add_line(result)
                             progress.update(1)
                 csvfile.save()
-    with CsvFile('reads.csv') as csvfile:
+    with CsvFile(intermediate_path) as csvfile:
         body = csvfile.body
         logging.info("GOT %s alignments", len(body))
 
-        with CsvFile('output.csv') as outputfile:
+        with CsvFile(csvfile_path) as outputfile:
             outputfile.rebase([
                     "id",
                     "first_exon",
@@ -106,9 +106,9 @@ def workflow(
                     "second_exon",
                     "intron_is_canonic"
                 ])
-                
+
             with tqdm(total=len(body),
-                          desc="saving results") as progress:
+                      desc="saving results") as progress:
                 logging.info("OPENED tqdm")
                 for alignment in body:
                     outputfile.add_line([
@@ -146,9 +146,17 @@ def apply_config(config: argparse.Namespace):
         config.bam,
         config.fasta,
         config.chromosome,
-        config.csv,
+        config.output,
+        config.intermediate_path,
         config.jobs)
 
 
-if __name__ == "__main__":
+def main():
+    """
+        @does define entry point
+    """
     command_line_interface()
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/__main__.py
+++ b/lib/__main__.py
@@ -147,7 +147,7 @@ def apply_config(config: argparse.Namespace):
         config.fasta,
         config.chromosome,
         config.output,
-        config.intermediate_path,
+        config.intermediate,
         config.jobs)
 
 

--- a/lib/aligned_segment.py
+++ b/lib/aligned_segment.py
@@ -2,8 +2,9 @@
     @represents a useful abstraction for pysam.AlignedSegment
 """
 
-from lib import CigarOperation
 import pysam
+
+from lib import CigarOperation
 from lib import cigar_tuples_to_cigar_string
 from lib import CIGAR_OPERATIONS_THAT_CONSUME_QUERY
 
@@ -54,8 +55,9 @@ class AlignedSegment:
         if cigar_string is None:
             cigar_string = cigar_tuples_to_cigar_string(cigar_tuples)
         if query_sequence_length is None:
-            query_sequence_length = sum([op[1] for op in cigar_tuples 
-                if op[0] in CIGAR_OPERATIONS_THAT_CONSUME_QUERY])
+            query_sequence_length = (
+                sum([op[1] for op in cigar_tuples
+                     if op[0] in CIGAR_OPERATIONS_THAT_CONSUME_QUERY]))
         if query_alignment_start is None:
             query_alignment_start = 0
             for op in cigar_tuples:
@@ -65,8 +67,10 @@ class AlignedSegment:
                     break
         if query_alignment_end is None:
             query_alignment_end = (
-                query_sequence_length - sum([op[1] for op in cigar_tuples 
-                    if op[0] == CigarOperation.S]) + query_alignment_start)
+                query_sequence_length -
+                sum([op[1] for op in cigar_tuples
+                     if op[0] == CigarOperation.S]) +
+                query_alignment_start)
         if reference_start is None:
             reference_start = 0
         if reference_end is None:

--- a/lib/alignment_worker.py
+++ b/lib/alignment_worker.py
@@ -24,31 +24,31 @@ class AlignmentWorker:
         self.__reference = None
 
     @staticmethod
-    def reverse_complement(seq : str) -> str:
+    def reverse_complement(seq: str) -> str:
         '''
             @does compute R&C of the seq
         '''
         reverse = seq[::-1]
         return (reverse.translate(str.maketrans('ATCG', "TAGC")))
-    
+
     def get_worker_id(self):
         """
             @does return the worker id
         """
         return self.__worker_id
-    
+
     def get_aligned_segment(self):
         """
             @does return the aligned_segment obj of the worker
         """
         return self.__aligned_segment
-    
+
     def get_reference(self):
         """
             @does return the reference obj of the worker
         """
         return self.__reference
-    
+
     def set_aligned_segment(self, aligned_segment: AlignedSegment):
         """
             @does assigns aligned_segment
@@ -187,8 +187,8 @@ class AlignmentWorker:
         intron_range = self.get_intron_range()
         is_reverse = self.__aligned_segment.get_is_reverse()
         return self.__reference.get_slice(intron_range[0],
-                                        intron_range[1],
-                                        is_reverse)
+                                          intron_range[1],
+                                          is_reverse)
 
     def split_read(self) -> tuple[str, str, str]:
         """
@@ -199,17 +199,16 @@ class AlignmentWorker:
             @uses intron
         """
         left_aligned_exon = self.get_left_aligned_exon()
-        right_aligned_exon = self.get_right_aligned_exon() 
+        right_aligned_exon = self.get_right_aligned_exon()
         intron = self.get_intron()
 
         is_reverse = self.__aligned_segment.get_is_reverse()
-        
-        first_aligned_exon = (self.reverse_complement(right_aligned_exon) 
+
+        first_aligned_exon = (self.reverse_complement(right_aligned_exon)
                               if is_reverse else left_aligned_exon)
-        second_aligned_exon = (self.reverse_complement(left_aligned_exon) 
-                              if is_reverse else right_aligned_exon)
+        second_aligned_exon = (self.reverse_complement(left_aligned_exon)
+                               if is_reverse else right_aligned_exon)
         return (first_aligned_exon, intron, second_aligned_exon)
-            
 
     def process_alignment(self) -> list:
         """"

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -16,7 +16,7 @@ class CLI:
             @does initialize CLI
         """
         self.__argument_parser = argparse.ArgumentParser(
-            prog="main",
+            prog="genomic",
             description=("this python module identifies " +
                          "introns and exons in reads " +
                          "when given FASTA and BAM"),
@@ -45,9 +45,16 @@ class CLI:
             help="supply chromosome name, default = 'X'")
 
         self.__argument_parser.add_argument(
-            "-o", "--output",
+            "-i", "--intermediate",
             type=str, default="reads.csv",
-            help="supply output csv file path, default = 'reads.csv'")
+            help="supply csv file path for intermediate file " +
+                 "that contains all data extracted from BAM/FASTA, " +
+                 "default = 'reads.csv'")
+
+        self.__argument_parser.add_argument(
+            "-o", "--output",
+            type=str, default="output.csv",
+            help="supply output csv file path, default = 'output.csv'")
 
         self.__argument_parser.add_argument(
             "-r", "--logfile",
@@ -84,6 +91,5 @@ class CLI:
             config.loglevel = "ERROR"
         if config.jobs is None or config.jobs < 1:
             config.jobs = os.cpu_count()
-        config.csv = config.output
 
         return config

--- a/lib/csv_file.py
+++ b/lib/csv_file.py
@@ -25,7 +25,7 @@ class CsvFile:
             @does get __body value in readonly
         '''
         return self.__body
-    
+
     @property
     def header(self) -> str:
         '''

--- a/lib/fasta_file.py
+++ b/lib/fasta_file.py
@@ -25,7 +25,7 @@ class FastaFile:
         """
             @returns list of reference names
         """
-        return [_ for _ in self.__index]
+        return list(self.__index)
 
     def get_reference(self, name: str) -> Reference:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 "Bug Tracker" = "https://github.com/frefolli/bioinf-progetto/issues"
 
 [project.scripts]
-genomic = "lib.__main__:command_line_interface"
+genomic = "lib.__main__:main"
 
 [tool.hatch.build]
 include = [

--- a/tests/alignment_test.py
+++ b/tests/alignment_test.py
@@ -227,7 +227,8 @@ class AlignmentGetRightExonTest(unittest.TestCase):
                 (CigarOperation.S, 2)
             ])
         alignment = craft_alignment_worker(aligned_segment)
-        self.assertEqual(11, alignment.get_aligned_segment().get_query_alignment_end())
+        self.assertEqual(11, (
+            alignment.get_aligned_segment().get_query_alignment_end()))
         self.assertEqual((5, 11), alignment.get_right_aligned_exon_range())
 
     def test_get_right_aligned_exon(self):
@@ -257,12 +258,12 @@ class AlignmentGetRightExonTest(unittest.TestCase):
             ],
             query_sequence="ACGTCCCGGCCAA")
         alignment = craft_alignment_worker(aligned_segment)
-        self.assertEqual(0, 
-            alignment.get_aligned_segment().get_query_alignment_start())
-        self.assertEqual(13, 
-            alignment.get_aligned_segment().get_query_sequence_length())
-        self.assertEqual(11, 
-            alignment.get_aligned_segment().get_query_alignment_end())
+        self.assertEqual(0, (
+            alignment.get_aligned_segment().get_query_alignment_start()))
+        self.assertEqual(13, (
+            alignment.get_aligned_segment().get_query_sequence_length()))
+        self.assertEqual(11, (
+            alignment.get_aligned_segment().get_query_alignment_end()))
         self.assertEqual("CCGGCC", alignment.get_right_aligned_exon())
 
 
@@ -453,7 +454,12 @@ class AlignmentGetIntronTest(unittest.TestCase):
         alignment = craft_alignment_worker(aligned_segment, reference)
         self.assertEqual("CCCCG", alignment.get_intron())
 
+
 class AlignmentGetPartsOnForwardStrandTest(unittest.TestCase):
+    """
+        @define test class for getting parts on forward strand
+    """
+
     def test_get_parts_from_alignment(self):
         """
             @does test
@@ -472,7 +478,7 @@ class AlignmentGetPartsOnForwardStrandTest(unittest.TestCase):
         self.assertEqual("ACGTC", first_exon)
         self.assertEqual("AAAAA", str(intron))
         self.assertEqual("CCGGCC", second_exon)
-    
+
     def test_get_parts_from_alignment_with_soft_clipping(self):
         """
             @does test
@@ -492,8 +498,8 @@ class AlignmentGetPartsOnForwardStrandTest(unittest.TestCase):
         self.assertEqual("ACGTC", first_exon)
         self.assertEqual("AAAAA", str(intron))
         self.assertEqual("CCGGCC", second_exon)
-    
-    def test_get_parts_from_alignment_with_soft_clipping(self):
+
+    def test_get_parts_from_alignment_with_soft_clipping_2(self):
         """
             @does test
         """
@@ -513,7 +519,12 @@ class AlignmentGetPartsOnForwardStrandTest(unittest.TestCase):
         self.assertEqual("AAAAA", str(intron))
         self.assertEqual("CCGGCC", second_exon)
 
+
 class AlignmentGetPartsOnReverseStrandTest(unittest.TestCase):
+    """
+        @define test class for getting parts on reverse strand
+    """
+
     def test_get_parts_from_alignment_on_reverse_strand(self):
         """
             @does test
@@ -534,7 +545,7 @@ class AlignmentGetPartsOnReverseStrandTest(unittest.TestCase):
         self.assertEqual("TTTTT", str(intron))
         self.assertEqual("GACGT", second_exon)
 
-    def test_get_parts_from_alignment_with_soft_clipping(self):
+    def test_get_parts_from_alignment_with_soft_clipping_right(self):
         """
             @does test
         """
@@ -551,11 +562,11 @@ class AlignmentGetPartsOnReverseStrandTest(unittest.TestCase):
         reference = Reference.from_name_and_sequence("X", "ACGTCAAAAACCGGCC")
         alignment = craft_alignment_worker(aligned_segment, reference)
         (first_exon, intron, second_exon) = alignment.split_read()
-        self.assertEqual("GGCCGACGT", first_exon)
+        self.assertEqual("GGCCGG", first_exon)
         self.assertEqual("TTTTT", str(intron))
-        self.assertEqual("GGCCGG", second_exon)
-    
-    def test_get_parts_from_alignment_with_soft_clipping(self):
+        self.assertEqual("GACGT", second_exon)
+
+    def test_get_parts_from_alignment_with_soft_clipping_left(self):
         """
             @does test
         """
@@ -575,4 +586,3 @@ class AlignmentGetPartsOnReverseStrandTest(unittest.TestCase):
         self.assertEqual("GGCCGG", first_exon)
         self.assertEqual("TTTTT", str(intron))
         self.assertEqual("GACGT", second_exon)
-    


### PR DESCRIPTION
Changelog:
- now intermediate file produced by genomic has a CLI flag called `--intermediate`
- now output file has the CLI flag `--output`
- solve various minor lint problems
- now actions.sh has new commands: lint, coverage, build
- now entry point in __main__.py is a new `main(): void` function which call the old entry point `command_line_interface`
- pyproject.toml now has new entry point `main`
- now in cli.py `prog` field in ArgumentParser constructor has "genomic" as value
- test test_get_parts_from_alignment_with_soft_clipping inside AlignmentGetPartsOnReverseStrandTest was masked by a test with the same name just after it, renaming both gave error in the first one: test was incorrect as second_exon was in fact first exon and first exon looked like second_exon. In fact was incorrect, i corrected it.
- added some docstrings 